### PR TITLE
Add model table utility with filtering

### DIFF
--- a/tests/test_recommended_models_table.py
+++ b/tests/test_recommended_models_table.py
@@ -1,0 +1,12 @@
+import pytest
+from utils import recommended_models_table
+
+def test_recommended_models_table_provider_filter():
+    table = recommended_models_table(provider='openai')
+    assert 'gpt-4o' in table
+    assert 'claude' not in table
+
+def test_recommended_models_table_task_image():
+    table = recommended_models_table(task='image')
+    assert 'dall-e-3' in table
+    assert 'gpt-4o' not in table


### PR DESCRIPTION
## Summary
- add `recommended_models_table` to display RECOMMENDED_MODELS in a filterable markdown table
- cover model table filtering with new tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'myapp')*


------
https://chatgpt.com/codex/tasks/task_e_68adeb6ca0008332980fe99e46dea965