### PR TITLE
Refine utils helpers and add coverage

### DIFF
--- a/myapp/__init__.py
+++ b/myapp/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+app = FastAPI()
+
+
+def get_db():
+    """Placeholder dependency used for tests."""
+    yield None

--- a/tests/test_recommended_models_table.py
+++ b/tests/test_recommended_models_table.py
@@ -1,4 +1,3 @@
-import pytest
 from utils import recommended_models_table
 
 def test_recommended_models_table_provider_filter():

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -1,0 +1,23 @@
+import os
+import uuid
+from utils import clean_llm_output, save_artifact, load_artifact, _find_project_root
+
+
+def test_clean_llm_output():
+    raw = "```json\n{\"a\": 1}\n```"
+    assert clean_llm_output(raw, language="json") == '{"a": 1}'
+
+
+def test_save_and_load_artifact():
+    filename = f"artifacts/{uuid.uuid4().hex}.txt"
+    content = "hello"
+    save_artifact(content, filename)
+    try:
+        assert load_artifact(filename) == content
+    finally:
+        full_path = os.path.join(_find_project_root(), filename)
+        if os.path.exists(full_path):
+            os.remove(full_path)
+            dir_path = os.path.dirname(full_path)
+            if os.path.isdir(dir_path) and not os.listdir(dir_path):
+                os.rmdir(dir_path)

--- a/utils.py
+++ b/utils.py
@@ -11,7 +11,7 @@ from PIL import Image
 from io import BytesIO
 import re
 import base64
-import time # For loading indicator
+import time  # For loading indicator
 
 # --- Dynamic Library Installation ---
 try:
@@ -379,17 +379,20 @@ def setup_llm_client(model_name="gpt-4o"):
         if api_provider == "openai":
             from openai import OpenAI
             api_key = os.getenv("OPENAI_API_KEY")
-            if not api_key: raise ValueError("OPENAI_API_KEY not found in .env file.")
+            if not api_key:
+                raise ValueError("OPENAI_API_KEY not found in .env file.")
             client = OpenAI(api_key=api_key)
         elif api_provider == "anthropic":
             from anthropic import Anthropic
             api_key = os.getenv("ANTHROPIC_API_KEY")
-            if not api_key: raise ValueError("ANTHROPIC_API_KEY not found in .env file.")
+            if not api_key:
+                raise ValueError("ANTHROPIC_API_KEY not found in .env file.")
             client = Anthropic(api_key=api_key)
         elif api_provider == "huggingface":
             from huggingface_hub import InferenceClient
             api_key = os.getenv("HUGGINGFACE_API_KEY")
-            if not api_key: raise ValueError("HUGGINGFACE_API_KEY not found in .env file.")
+            if not api_key:
+                raise ValueError("HUGGINGFACE_API_KEY not found in .env file.")
             client = InferenceClient(model=model_name, token=api_key)
         elif api_provider == "gemini" or api_provider == "google": # Google for image generation or STT
             if config.get("audio_transcription"):
@@ -397,8 +400,9 @@ def setup_llm_client(model_name="gpt-4o"):
                 client = speech.SpeechClient()
             else:
                 import google.generativeai as genai
-                api_key = os.getenv("GOOGLE_API_KEY") # Use GOOGLE_API_KEY for both Gemini text and Imagen
-                if not api_key: raise ValueError("GOOGLE_API_KEY not found in .env file.")
+                api_key = os.getenv("GOOGLE_API_KEY")  # Use GOOGLE_API_KEY for both Gemini text and Imagen
+                if not api_key:
+                    raise ValueError("GOOGLE_API_KEY not found in .env file.")
                 genai.configure(api_key=api_key)
                 if config["image_generation"]:
                     # For image generation, the client is not directly a GenerativeModel instance
@@ -419,7 +423,8 @@ def setup_llm_client(model_name="gpt-4o"):
 
 def get_completion(prompt, client, model_name, api_provider, temperature=0.7):
     """Sends a text-only prompt to the LLM and returns the completion."""
-    if not client: return "API client not initialized."
+    if not client:
+        return "API client not initialized."
     try:
         if api_provider == "openai":
             response = client.chat.completions.create(model=model_name, messages=[{"role": "user", "content": prompt}], temperature=temperature)
@@ -443,7 +448,8 @@ def get_completion(prompt, client, model_name, api_provider, temperature=0.7):
 
 def get_vision_completion(prompt, image_url, client, model_name, api_provider):
     """Sends an image and a text prompt to a vision-capable LLM and returns the completion."""
-    if not client: return "API client not initialized."
+    if not client:
+        return "API client not initialized."
     if not RECOMMENDED_MODELS.get(model_name, {}).get("vision"):
         return f"Error: Model '{model_name}' does not support vision."
     try:
@@ -513,7 +519,8 @@ def get_vision_completion(prompt, image_url, client, model_name, api_provider):
 
 def get_image_generation_completion(prompt, client, model_name, api_provider):
     """Generates an image from a text prompt using an image generation LLM."""
-    if not client: return "API client not initialized."
+    if not client:
+        return "API client not initialized."
     if not RECOMMENDED_MODELS.get(model_name, {}).get("image_generation"):
         return f"Error: Model '{model_name}' does not support image generation."
 


### PR DESCRIPTION
## Summary
- enforce PEP8 in `utils.py` by splitting inline conditionals and fixing import comments
- add minimal `myapp` stub so tests can run
- expand test coverage for utility helpers like `clean_llm_output` and artifact saving

## Testing
- `ruff check utils.py myapp/__init__.py tests/test_recommended_models_table.py tests/test_utils_helpers.py`
- `PYTHONPATH=. pytest -q tests/test_recommended_models_table.py tests/test_utils_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae2c45b73c8332a4a01aecf02a4077