### PR TITLE
refactor: raise exceptions instead of error strings

### DIFF
--- a/utils/errors.py
+++ b/utils/errors.py
@@ -13,3 +13,13 @@ class ArtifactSecurityError(ArtifactError):
 class ArtifactNotFoundError(ArtifactError):
     """Raised when an expected artifact is missing."""
     pass
+
+
+class ProviderOperationError(UtilsError):
+    """Error raised for provider/model operation failures."""
+
+    def __init__(self, provider: str, model: str, operation: str, message: str):
+        self.provider = provider
+        self.model = model
+        self.operation = operation
+        super().__init__(f"[{provider}:{model}] {operation} error: {message}")


### PR DESCRIPTION
## Summary
- replace string error returns with ProviderOperationError exceptions
- add deprecated *_compat wrappers that return (result, error)
- introduce ProviderOperationError class for consistent context

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'app')

------
https://chatgpt.com/codex/tasks/task_e_68c2cd3c646c8332a3b6f5d2fe74eacd