### PR TITLE
Add asynchronous LLM I/O utilities and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ pytest tests/
 jupyter notebook
 ```
 
+### 4. Asynchronous LLM Calls (Optional)
+
+The `utils` package includes async counterparts for I/O helpers. You can run many
+model calls concurrently using `asyncio.gather`:
+
+```python
+import asyncio
+from utils import async_setup_llm_client, async_get_completion
+
+async def main():
+    client, model, provider = await async_setup_llm_client()
+    prompts = [f"Hello {i}!" for i in range(5)]
+    tasks = [async_get_completion(p, client, model, provider) for p in prompts]
+    return await asyncio.gather(*tasks)
+
+results = asyncio.run(main())
+```
+
 ## 📚 Course Structure
 
 ### Week 1: AI-Assisted Software Development

--- a/async_tests/test_async_llm.py
+++ b/async_tests/test_async_llm.py
@@ -1,0 +1,41 @@
+import asyncio
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils import async_get_completion
+from utils import llm as llm_module
+
+
+class DummyProvider:
+    @staticmethod
+    async def async_text_completion(client, prompt, model_name, temperature=0.7):
+        await asyncio.sleep(0.1)
+        return f"resp-{prompt}"
+
+
+def setup_dummy_provider(monkeypatch):
+    monkeypatch.setitem(llm_module.PROVIDERS, "dummy", DummyProvider)
+
+
+@pytest.mark.asyncio
+async def test_async_get_completion_parallel(monkeypatch):
+    setup_dummy_provider(monkeypatch)
+    client = object()
+    prompts = [f"p{i}" for i in range(5)]
+
+    start = time.perf_counter()
+    for p in prompts:
+        await async_get_completion(p, client, "model", "dummy")
+    sequential = time.perf_counter() - start
+
+    start = time.perf_counter()
+    await asyncio.gather(
+        *(async_get_completion(p, client, "model", "dummy") for p in prompts)
+    )
+    parallel = time.perf_counter() - start
+
+    assert parallel < sequential / 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ flask
 
 # Testing
 pytest
+pytest-asyncio
 
 # Environment helpers
 python-dotenv

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,17 +7,26 @@ submodules to make it easier to maintain and to add new providers.
 from .settings import load_environment, load_dotenv, display, Markdown, IPyImage, PlantUML
 from .models import RECOMMENDED_MODELS, recommended_models_table
 from .llm import (
-    setup_llm_client,
+    setup_llm_client, async_setup_llm_client,
     get_completion, get_completion_compat,
+    async_get_completion, async_get_completion_compat,
     get_vision_completion, get_vision_completion_compat,
+    async_get_vision_completion, async_get_vision_completion_compat,
     clean_llm_output,
     prompt_enhancer, prompt_enhancer_compat,
 )
 from .image_gen import (
     get_image_generation_completion, get_image_generation_completion_compat,
+    async_get_image_generation_completion, async_get_image_generation_completion_compat,
     get_image_edit_completion, get_image_edit_completion_compat,
+    async_get_image_edit_completion, async_get_image_edit_completion_compat,
 )
-from .audio import transcribe_audio, transcribe_audio_compat
+from .audio import (
+    transcribe_audio,
+    transcribe_audio_compat,
+    async_transcribe_audio,
+    async_transcribe_audio_compat,
+)
 from .artifacts import *  # noqa: F401,F403 re-export for backwards compatibility
 from .errors import *  # noqa: F401,F403
 from .logging import *  # noqa: F401,F403
@@ -25,10 +34,16 @@ from .logging import *  # noqa: F401,F403
 __all__ = [
     'load_environment', 'load_dotenv', 'display', 'Markdown', 'IPyImage', 'PlantUML',
     'RECOMMENDED_MODELS', 'recommended_models_table',
-    'setup_llm_client', 'get_completion', 'get_completion_compat',
+    'setup_llm_client', 'async_setup_llm_client',
+    'get_completion', 'get_completion_compat',
+    'async_get_completion', 'async_get_completion_compat',
     'get_vision_completion', 'get_vision_completion_compat',
+    'async_get_vision_completion', 'async_get_vision_completion_compat',
     'get_image_generation_completion', 'get_image_generation_completion_compat',
+    'async_get_image_generation_completion', 'async_get_image_generation_completion_compat',
     'get_image_edit_completion', 'get_image_edit_completion_compat',
+    'async_get_image_edit_completion', 'async_get_image_edit_completion_compat',
     'transcribe_audio', 'transcribe_audio_compat',
+    'async_transcribe_audio', 'async_transcribe_audio_compat',
     'clean_llm_output', 'prompt_enhancer', 'prompt_enhancer_compat',
 ]

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import asyncio
 from typing import Any
 
 from .errors import ProviderOperationError
@@ -21,6 +22,45 @@ def transcribe_audio(audio_path: str, client: Any, model_name: str, api_provider
     return provider_module.transcribe_audio(client, audio_path, model_name, language_code)
 
 
+async def async_transcribe_audio(
+    audio_path: str,
+    client: Any,
+    model_name: str,
+    api_provider: str,
+    language_code: str = "en-US",
+) -> str:
+    if not client:
+        raise ProviderOperationError(
+            api_provider, model_name, "audio transcription", "API client not initialized."
+        )
+    if not RECOMMENDED_MODELS.get(model_name, {}).get("audio_transcription"):
+        raise ProviderOperationError(
+            api_provider,
+            model_name,
+            "audio transcription",
+            f"Model '{model_name}' does not support audio transcription.",
+        )
+    if not os.path.exists(audio_path):
+        raise ProviderOperationError(
+            api_provider,
+            model_name,
+            "audio transcription",
+            f"Audio file not found at {audio_path}",
+        )
+    provider_module = PROVIDERS.get(api_provider)
+    if not provider_module:
+        raise ProviderOperationError(
+            api_provider, model_name, "audio transcription", "Unsupported provider"
+        )
+    if hasattr(provider_module, "async_transcribe_audio"):
+        return await provider_module.async_transcribe_audio(
+            client, audio_path, model_name, language_code
+        )
+    return await asyncio.to_thread(
+        provider_module.transcribe_audio, client, audio_path, model_name, language_code
+    )
+
+
 def transcribe_audio_compat(audio_path: str, client: Any, model_name: str, api_provider: str, language_code: str = "en-US"):
     try:
         return transcribe_audio(audio_path, client, model_name, api_provider, language_code), None
@@ -28,4 +68,22 @@ def transcribe_audio_compat(audio_path: str, client: Any, model_name: str, api_p
         return None, str(e)
 
 
-__all__ = ['transcribe_audio', 'transcribe_audio_compat']
+async def async_transcribe_audio_compat(
+    audio_path: str,
+    client: Any,
+    model_name: str,
+    api_provider: str,
+    language_code: str = "en-US",
+):
+    try:
+        return (
+            await async_transcribe_audio(
+                audio_path, client, model_name, api_provider, language_code
+            ),
+            None,
+        )
+    except ProviderOperationError as e:
+        return None, str(e)
+
+
+__all__ = ['transcribe_audio', 'transcribe_audio_compat', 'async_transcribe_audio', 'async_transcribe_audio_compat']

--- a/utils/image_gen.py
+++ b/utils/image_gen.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import mimetypes
 import time
+import asyncio
 from typing import Any, Tuple
 
 from .errors import ProviderOperationError
@@ -31,9 +32,44 @@ def get_image_generation_completion(prompt: str, client: Any, model_name: str, a
     return _save_image(image_data_base64, image_mime)
 
 
+async def async_get_image_generation_completion(
+    prompt: str, client: Any, model_name: str, api_provider: str
+) -> Tuple[str, str]:
+    if not client:
+        raise ProviderOperationError(
+            api_provider, model_name, "image generation", "API client not initialized."
+        )
+    provider_module = PROVIDERS.get(api_provider)
+    if not provider_module:
+        raise ProviderOperationError(
+            api_provider, model_name, "image generation", "Unsupported provider"
+        )
+    if hasattr(provider_module, "async_image_generation"):
+        image_data_base64, image_mime = await provider_module.async_image_generation(
+            client, prompt, model_name
+        )
+    else:
+        image_data_base64, image_mime = await asyncio.to_thread(
+            provider_module.image_generation, client, prompt, model_name
+        )
+    return _save_image(image_data_base64, image_mime)
+
+
 def get_image_generation_completion_compat(prompt: str, client: Any, model_name: str, api_provider: str):
     try:
         return get_image_generation_completion(prompt, client, model_name, api_provider), None
+    except ProviderOperationError as e:
+        return None, str(e)
+
+
+async def async_get_image_generation_completion_compat(
+    prompt: str, client: Any, model_name: str, api_provider: str
+):
+    try:
+        return (
+            await async_get_image_generation_completion(prompt, client, model_name, api_provider),
+            None,
+        )
     except ProviderOperationError as e:
         return None, str(e)
 
@@ -48,6 +84,30 @@ def get_image_edit_completion(prompt: str, image_path: str, client: Any, model_n
     return _save_image(image_data_base64, image_mime)
 
 
+async def async_get_image_edit_completion(
+    prompt: str,
+    image_path: str,
+    client: Any,
+    model_name: str,
+    api_provider: str,
+    **edit_params: Any,
+) -> Tuple[str, str]:
+    if not client:
+        raise ProviderOperationError(api_provider, model_name, "image edit", "API client not initialized.")
+    provider_module = PROVIDERS.get(api_provider)
+    if not provider_module:
+        raise ProviderOperationError(api_provider, model_name, "image edit", "Unsupported provider")
+    if hasattr(provider_module, "async_image_edit"):
+        image_data_base64, image_mime = await provider_module.async_image_edit(
+            client, prompt, image_path, model_name, **edit_params
+        )
+    else:
+        image_data_base64, image_mime = await asyncio.to_thread(
+            provider_module.image_edit, client, prompt, image_path, model_name, **edit_params
+        )
+    return _save_image(image_data_base64, image_mime)
+
+
 def get_image_edit_completion_compat(prompt: str, image_path: str, client: Any, model_name: str, api_provider: str, **edit_params: Any):
     try:
         return get_image_edit_completion(prompt, image_path, client, model_name, api_provider, **edit_params), None
@@ -55,7 +115,28 @@ def get_image_edit_completion_compat(prompt: str, image_path: str, client: Any, 
         return None, str(e)
 
 
+async def async_get_image_edit_completion_compat(
+    prompt: str,
+    image_path: str,
+    client: Any,
+    model_name: str,
+    api_provider: str,
+    **edit_params: Any,
+):
+    try:
+        return (
+            await async_get_image_edit_completion(
+                prompt, image_path, client, model_name, api_provider, **edit_params
+            ),
+            None,
+        )
+    except ProviderOperationError as e:
+        return None, str(e)
+
+
 __all__ = [
     'get_image_generation_completion', 'get_image_generation_completion_compat',
-    'get_image_edit_completion', 'get_image_edit_completion_compat'
+    'async_get_image_generation_completion', 'async_get_image_generation_completion_compat',
+    'get_image_edit_completion', 'get_image_edit_completion_compat',
+    'async_get_image_edit_completion', 'async_get_image_edit_completion_compat'
 ]

--- a/utils/providers/anthropic.py
+++ b/utils/providers/anthropic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import asyncio
 from typing import Any, Tuple
 
 from ..errors import ProviderOperationError
@@ -14,6 +15,10 @@ def setup_client(model_name: str, config: dict[str, Any]):
     if not api_key:
         raise ValueError("ANTHROPIC_API_KEY not found in .env file.")
     return Anthropic(api_key=api_key)
+
+
+async def async_setup_client(model_name: str, config: dict[str, Any]):
+    return await asyncio.to_thread(setup_client, model_name, config)
 
 
 def text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
@@ -32,17 +37,37 @@ def text_completion(client: Any, prompt: str, model_name: str, temperature: floa
         raise ProviderOperationError("anthropic", model_name, "completion", str(e))
 
 
+async def async_text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
+    return await asyncio.to_thread(text_completion, client, prompt, model_name, temperature)
+
+
 def vision_completion(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("anthropic", kwargs.get("model_name", ""), "vision", "Not implemented")
+
+
+async def async_vision_completion(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(vision_completion, *args, **kwargs)
 
 
 def image_generation(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("anthropic", kwargs.get("model_name", ""), "image generation", "Not implemented")
 
 
+async def async_image_generation(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(image_generation, *args, **kwargs)
+
+
 def image_edit(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("anthropic", kwargs.get("model_name", ""), "image edit", "Not implemented")
 
 
+async def async_image_edit(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(image_edit, *args, **kwargs)
+
+
 def transcribe_audio(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("anthropic", kwargs.get("model_name", ""), "audio transcription", "Not implemented")
+
+
+async def async_transcribe_audio(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(transcribe_audio, *args, **kwargs)

--- a/utils/providers/google.py
+++ b/utils/providers/google.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import asyncio
 from typing import Any, Tuple
 
 from ..errors import ProviderOperationError
@@ -23,6 +24,10 @@ def setup_client(model_name: str, config: dict[str, Any]):
     return genai.GenerativeModel(model_name)
 
 
+async def async_setup_client(model_name: str, config: dict[str, Any]):
+    return await asyncio.to_thread(setup_client, model_name, config)
+
+
 def text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
     try:
         api_key = os.getenv("GOOGLE_API_KEY", "")
@@ -35,8 +40,16 @@ def text_completion(client: Any, prompt: str, model_name: str, temperature: floa
         raise ProviderOperationError("google", model_name, "completion", str(e))
 
 
+async def async_text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
+    return await asyncio.to_thread(text_completion, client, prompt, model_name, temperature)
+
+
 def vision_completion(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("google", kwargs.get("model_name", ""), "vision", "Not implemented")
+
+
+async def async_vision_completion(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(vision_completion, *args, **kwargs)
 
 
 def image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, str]:
@@ -54,8 +67,16 @@ def image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, st
     raise ProviderOperationError("google", model_name, "image generation", "Not implemented for this model")
 
 
+async def async_image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, str]:
+    return await asyncio.to_thread(image_generation, client, prompt, model_name)
+
+
 def image_edit(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("google", kwargs.get("model_name", ""), "image edit", "Not implemented")
+
+
+async def async_image_edit(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(image_edit, *args, **kwargs)
 
 
 def transcribe_audio(client: Any, audio_path: str, model_name: str, language_code: str = "en-US") -> str:
@@ -69,5 +90,16 @@ def transcribe_audio(client: Any, audio_path: str, model_name: str, language_cod
     if response.results:
         return response.results[0].alternatives[0].transcript
     raise ProviderOperationError(
-        "google", model_name, "audio transcription", "No transcription result from Google Speech-to-Text."
+        "google",
+        model_name,
+        "audio transcription",
+        "No transcription result from Google Speech-to-Text.",
+    )
+
+
+async def async_transcribe_audio(
+    client: Any, audio_path: str, model_name: str, language_code: str = "en-US"
+) -> str:
+    return await asyncio.to_thread(
+        transcribe_audio, client, audio_path, model_name, language_code
     )

--- a/utils/providers/huggingface.py
+++ b/utils/providers/huggingface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from io import BytesIO
 import base64
+import asyncio
 from typing import Any, Tuple
 
 from ..errors import ProviderOperationError
@@ -16,6 +17,10 @@ def setup_client(model_name: str, config: dict[str, Any]):
     if not api_key:
         raise ValueError("HUGGINGFACE_API_KEY not found in .env file.")
     return InferenceClient(model=model_name, token=api_key)
+
+
+async def async_setup_client(model_name: str, config: dict[str, Any]):
+    return await asyncio.to_thread(setup_client, model_name, config)
 
 
 def text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
@@ -33,8 +38,16 @@ def text_completion(client: Any, prompt: str, model_name: str, temperature: floa
         raise ProviderOperationError("huggingface", model_name, "completion", str(e))
 
 
+async def async_text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
+    return await asyncio.to_thread(text_completion, client, prompt, model_name, temperature)
+
+
 def vision_completion(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("huggingface", kwargs.get("model_name", ""), "vision", "Not implemented")
+
+
+async def async_vision_completion(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(vision_completion, *args, **kwargs)
 
 
 def image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, str]:
@@ -46,9 +59,21 @@ def image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, st
     return base64.b64encode(buffered.getvalue()).decode("utf-8"), "image/png"
 
 
+async def async_image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, str]:
+    return await asyncio.to_thread(image_generation, client, prompt, model_name)
+
+
 def image_edit(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("huggingface", kwargs.get("model_name", ""), "image edit", "Not implemented")
 
 
+async def async_image_edit(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(image_edit, *args, **kwargs)
+
+
 def transcribe_audio(*args, **kwargs):  # pragma: no cover
     raise ProviderOperationError("huggingface", kwargs.get("model_name", ""), "audio transcription", "Not implemented")
+
+
+async def async_transcribe_audio(*args, **kwargs):  # pragma: no cover
+    return await asyncio.to_thread(transcribe_audio, *args, **kwargs)

--- a/utils/providers/openai.py
+++ b/utils/providers/openai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import base64
+import asyncio
 from typing import Any, Tuple
 
 from ..errors import ProviderOperationError
@@ -15,6 +16,14 @@ def setup_client(model_name: str, config: dict[str, Any]):
     if not api_key:
         raise ValueError("OPENAI_API_KEY not found in .env file.")
     return OpenAI(api_key=api_key)
+
+
+async def async_setup_client(model_name: str, config: dict[str, Any]):
+    from openai import AsyncOpenAI
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY not found in .env file.")
+    return AsyncOpenAI(api_key=api_key)
 
 
 def text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
@@ -45,7 +54,39 @@ def text_completion(client: Any, prompt: str, model_name: str, temperature: floa
         raise ProviderOperationError("openai", model_name, "completion", str(e))
 
 
+async def async_text_completion(client: Any, prompt: str, model_name: str, temperature: float = 0.7) -> str:
+    try:
+        api_key = os.getenv("OPENAI_API_KEY", "")
+        rate_limit("openai", api_key, model_name)
+        try:
+            response = await client.chat.completions.create(
+                model=model_name,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=temperature,
+                timeout=TOTAL_TIMEOUT,
+            )
+            return response.choices[0].message.content
+        except Exception as api_error:
+            if "v1/responses" in str(api_error):
+                response = await client.responses.create(
+                    model=model_name,
+                    input=prompt,
+                    temperature=temperature,
+                    timeout=TOTAL_TIMEOUT,
+                )
+                if hasattr(response, "text"):
+                    return response.text
+                return response.choices[0].text
+            raise api_error
+    except Exception as e:  # pragma: no cover - network dependent
+        raise ProviderOperationError("openai", model_name, "completion", str(e))
+
+
 def vision_completion(*args, **kwargs):  # pragma: no cover - heavy network
+    raise ProviderOperationError("openai", kwargs.get("model_name", ""), "vision", "Not implemented in this environment")
+
+
+async def async_vision_completion(*args, **kwargs):  # pragma: no cover - heavy network
     raise ProviderOperationError("openai", kwargs.get("model_name", ""), "vision", "Not implemented in this environment")
 
 
@@ -58,6 +99,22 @@ def image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, st
     response = client.images.generate(timeout=TOTAL_TIMEOUT, **params)
     if model_name == "gpt-image-1" and response.data[0].url:
         img_resp = request("GET", response.data[0].url)
+        img_resp.raise_for_status()
+        image_data_base64 = base64.b64encode(img_resp.content).decode("utf-8")
+    else:
+        image_data_base64 = response.data[0].b64_json
+    return image_data_base64, "image/png"
+
+
+async def async_image_generation(client: Any, prompt: str, model_name: str) -> Tuple[str, str]:
+    api_key = os.getenv("OPENAI_API_KEY", "")
+    rate_limit("openai", api_key, model_name)
+    params = {"model": model_name, "prompt": prompt, "n": 1, "size": "1024x1024"}
+    if model_name != "gpt-image-1":
+        params["response_format"] = "b64_json"
+    response = await client.images.generate(timeout=TOTAL_TIMEOUT, **params)
+    if model_name == "gpt-image-1" and response.data[0].url:
+        img_resp = await asyncio.to_thread(request, "GET", response.data[0].url)
         img_resp.raise_for_status()
         image_data_base64 = base64.b64encode(img_resp.content).decode("utf-8")
     else:
@@ -79,11 +136,41 @@ def image_edit(client: Any, prompt: str, image_path: str, model_name: str, **edi
     return response.data[0].b64_json, "image/png"
 
 
+async def async_image_edit(
+    client: Any, prompt: str, image_path: str, model_name: str, **edit_params: Any
+) -> Tuple[str, str]:
+    api_key = os.getenv("OPENAI_API_KEY", "")
+    rate_limit("openai", api_key, model_name)
+    with open(image_path, "rb") as image_file:
+        response = await client.images.edit(
+            model=model_name,
+            image=image_file,
+            prompt=prompt,
+            timeout=TOTAL_TIMEOUT,
+            **edit_params,
+        )
+    return response.data[0].b64_json, "image/png"
+
+
 def transcribe_audio(client: Any, audio_path: str, model_name: str, language_code: str = "en-US") -> str:
     api_key = os.getenv("OPENAI_API_KEY", "")
     rate_limit("openai", api_key, model_name)
     with open(audio_path, "rb") as audio_file:
         transcription = client.audio.transcriptions.create(
+            model=model_name,
+            file=audio_file,
+            timeout=TOTAL_TIMEOUT,
+        )
+    return transcription.text
+
+
+async def async_transcribe_audio(
+    client: Any, audio_path: str, model_name: str, language_code: str = "en-US"
+) -> str:
+    api_key = os.getenv("OPENAI_API_KEY", "")
+    rate_limit("openai", api_key, model_name)
+    with open(audio_path, "rb") as audio_file:
+        transcription = await client.audio.transcriptions.create(
             model=model_name,
             file=audio_file,
             timeout=TOTAL_TIMEOUT,


### PR DESCRIPTION
## Summary
- extend utils with async_setup_llm_client and async_* helpers for completion, vision, image generation, and audio transcription
- document parallel async usage in README
- add pytest-asyncio test exercising parallel completions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `pytest async_tests`

------
https://chatgpt.com/codex/tasks/task_e_68c2e59b81308332b5e52a39504ea8a5