### PR TITLE
docs: clarify utils behavior and add guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ docker run -p 8000:8000 --env-file .env ai-software-engineering
 - **[Docker Guide](Supporting%20Materials/Docker_Guide.md)**: Container deployment guide
 - **[API Key Generation Guide](Supporting%20Materials/🔑%20API%20Key%20Generation%20Guide%20for%20Labs.pdf)**: Step-by-step API setup
 - **[React Components Guide](Supporting%20Materials/How_to_View_Your_React_Components_Locally.md)**: Frontend development setup
+- **[Productionizing Utils](Supporting%20Materials/Productionizing_Utils.md)**: Timeouts, retries, rate limiting, and logging
+- **[Artifacts Guide](Supporting%20Materials/Artifacts_Guide.md)**: Artifact directory overrides and security
+
+## 🕰️ Deprecations
+
+Legacy helpers that returned ``(result, error_str)`` are deprecated.  Update
+existing code to call the standard functions and catch
+``ProviderOperationError`` instead.  Compatibility wrappers remain temporarily
+for transition but will be removed in a future release.
 
 ## 🤝 Contributing
 

--- a/Supporting Materials/Artifacts_Guide.md
+++ b/Supporting Materials/Artifacts_Guide.md
@@ -1,0 +1,37 @@
+# Artifacts Guide
+
+Utilities in `utils.artifacts` manage generated files with strict directory
+rules.
+
+## Resolution Flow
+
+```mermaid
+flowchart TD
+    A[start] --> B{base_dir provided?}
+    B -- yes --> C[use base_dir]
+    B -- no --> D{set_artifacts_dir called?}
+    D -- yes --> E[use override]
+    D -- no --> F{AGA_ARTIFACTS_DIR env?}
+    F -- yes --> G[use env dir]
+    F -- no --> H[project_root/artifacts]
+```
+
+## Security
+
+Paths must remain within the resolved artifacts directory.
+
+```mermaid
+flowchart LR
+    P[requested path] --> Q{inside artifacts dir?}
+    Q -- no --> X[raise ArtifactSecurityError]
+    Q -- yes --> Y[allow]
+```
+
+## Basic Usage
+
+```python
+from utils.artifacts import save_artifact, load_artifact
+
+save_artifact("hello", "greeting.txt")
+print(load_artifact("greeting.txt", as_="text"))
+```

--- a/Supporting Materials/Productionizing_Utils.md
+++ b/Supporting Materials/Productionizing_Utils.md
@@ -1,0 +1,48 @@
+# Productionizing Utils
+
+This guide covers configuration options for the `utils` helpers when moving from
+experiments to production environments.
+
+## Timeouts and Retries
+
+HTTP helpers use sensible defaults that can be tuned with environment
+variables:
+
+- `UTILS_TIMEOUT_CONNECT` – connection timeout in seconds (default `10`)
+- `UTILS_TIMEOUT_READ` – read timeout in seconds (default `60`)
+- `UTILS_MAX_RETRIES` – number of retry attempts for transient errors (default `3`)
+
+Example:
+
+```python
+from utils.http import request
+
+response = request("GET", "https://httpbin.org/get")
+print(response.status_code)
+```
+
+## Rate Limiting
+
+Rate limiting is enforced per provider/API key/model using a token bucket. Enable
+it by setting `UTILS_RATE_LIMIT_QPS_<PROVIDER>` to the allowed queries per
+second.
+
+```python
+import os
+from utils.rate_limit import rate_limit
+
+os.environ["UTILS_RATE_LIMIT_QPS_OPENAI"] = "1"
+rate_limit("openai", "fake-key", "gpt-4o")
+```
+
+## Logging
+
+Use `utils.logging.get_logger` to emit structured logs. The log level can be
+controlled with `UTILS_LOG_LEVEL`.
+
+```python
+from utils.logging import get_logger
+
+logger = get_logger()
+logger.info("hello from utils")
+```

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -1,3 +1,16 @@
+"""Artifact helpers with safe path resolution.
+
+Path resolution priority::
+
+    1. ``base_dir`` argument
+    2. Directory set via :func:`set_artifacts_dir`
+    3. ``AGA_ARTIFACTS_DIR`` environment variable
+    4. ``<project_root>/artifacts``
+
+All operations raise :class:`ArtifactError` subclasses instead of returning
+error strings.
+"""
+
 import io
 import json
 import os
@@ -10,6 +23,7 @@ _ARTIFACTS_DIR: Optional[Path] = None
 _PROJECT_MARKERS = frozenset({"pyproject.toml", ".git", "requirements.txt", "setup.cfg", "README.md"})
 
 def detect_project_root(start: Optional[Path] = None) -> Path:
+    """Walk upward from ``start`` to locate a project root."""
     start = start or Path.cwd()
     for p in [start, *start.parents]:
         if any((p / m).exists() for m in _PROJECT_MARKERS):
@@ -22,7 +36,15 @@ def detect_project_root(start: Optional[Path] = None) -> Path:
     return Path.cwd()
 
 def set_artifacts_dir(path: Union[str, Path]) -> Path:
-    """Set a custom artifacts directory; created if missing."""
+    """Set a custom artifacts directory.
+
+    The directory is created if missing and used for subsequent operations.
+
+    Example
+    -------
+    >>> set_artifacts_dir("~/my_artifacts")
+    PosixPath('/home/user/my_artifacts')
+    """
     global _ARTIFACTS_DIR
     p = Path(path).expanduser().resolve()
     p.mkdir(parents=True, exist_ok=True)
@@ -30,6 +52,14 @@ def set_artifacts_dir(path: Union[str, Path]) -> Path:
     return p
 
 def get_artifacts_dir(base_dir: Optional[Union[str, Path]] = None) -> Path:
+    """Return the active artifacts directory.
+
+    Resolution order:
+      1. Explicit ``base_dir`` argument
+      2. Directory previously set via :func:`set_artifacts_dir`
+      3. ``AGA_ARTIFACTS_DIR`` environment variable
+      4. ``<project_root>/artifacts``
+    """
     if base_dir is not None:
         return Path(base_dir).expanduser().resolve()
     if _ARTIFACTS_DIR is not None:
@@ -54,18 +84,31 @@ def resolve_artifact_path(
     subdir: Optional[Union[str, Path]] = None,
     must_exist: bool = False
 ) -> Path:
+    """Resolve ``filename`` against the artifacts directory.
+
+    Raises
+    ------
+    ArtifactSecurityError
+        If the resolved path escapes the artifacts directory.
+    ArtifactNotFoundError
+        If ``must_exist`` is ``True`` and the file is missing.
+    """
     base = get_artifacts_dir(base_dir)
     target = Path(filename)
     if target.is_absolute():
         resolved = target.resolve()
         if not _is_within(resolved, base):
-            raise ArtifactSecurityError(f"Absolute path '{resolved}' is outside artifacts dir '{base}'.")
+            raise ArtifactSecurityError(
+                f"Absolute path '{resolved}' is outside artifacts dir '{base}'."
+            )
         final = resolved
     else:
         # allow optional subdir
         final = (base / (Path(subdir) if subdir else Path()) / target).resolve()
         if not _is_within(final, base):
-            raise ArtifactSecurityError(f"Resolved path '{final}' escapes artifacts dir '{base}'.")
+            raise ArtifactSecurityError(
+                f"Resolved path '{final}' escapes artifacts dir '{base}'."
+            )
     if must_exist and not final.exists():
         raise ArtifactNotFoundError(f"Artifact not found: {final}")
     return final
@@ -80,10 +123,27 @@ def save_artifact(
     overwrite: bool = False,
     encoding: str = "utf-8",
 ) -> Path:
-    path = resolve_artifact_path(filename, base_dir=base_dir, subdir=subdir, must_exist=False)
+    """Persist ``content`` to the artifacts directory.
+
+    Raises
+    ------
+    ArtifactError
+        If the file exists and ``overwrite`` is ``False`` or the content type
+        is unsupported.
+
+    Example
+    -------
+    >>> save_artifact("hello", "greeting.txt")
+    PosixPath('.../artifacts/greeting.txt')
+    """
+    path = resolve_artifact_path(
+        filename, base_dir=base_dir, subdir=subdir, must_exist=False
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists() and not overwrite:
-        raise ArtifactError(f"Artifact already exists: {path}. Pass overwrite=True to replace.")
+        raise ArtifactError(
+            f"Artifact already exists: {path}. Pass overwrite=True to replace."
+        )
 
     tmp = path.with_suffix(path.suffix + ".tmp")
     try:
@@ -92,7 +152,9 @@ def save_artifact(
         elif isinstance(content, io.BytesIO):
             tmp.write_bytes(content.getvalue())
         elif isinstance(content, dict):
-            tmp.write_text(json.dumps(content, ensure_ascii=False, indent=2), encoding=encoding)
+            tmp.write_text(
+                json.dumps(content, ensure_ascii=False, indent=2), encoding=encoding
+            )
         elif isinstance(content, str):
             tmp.write_text(content, encoding=encoding)
         else:
@@ -104,7 +166,9 @@ def save_artifact(
                 # file-like
                 tmp.write_bytes(content.read())
             else:
-                raise ArtifactError(f"Unsupported content type: {type(content)!r}")
+                raise ArtifactError(
+                    f"Unsupported content type: {type(content)!r}"
+                )
         os.replace(tmp, path)  # atomic
         return path
     except Exception:
@@ -123,7 +187,21 @@ def load_artifact(
     as_: Optional[Literal["bytes", "text", "json", "auto"]] = "auto",
     encoding: str = "utf-8",
 ) -> Union[bytes, str, dict, Any]:
-    path = resolve_artifact_path(filename, base_dir=base_dir, subdir=subdir, must_exist=True)
+    """Load content from the artifacts directory.
+
+    Raises
+    ------
+    ArtifactNotFoundError
+        If ``filename`` does not exist.
+
+    Example
+    -------
+    >>> load_artifact("greeting.txt", as_="text")
+    'hello'
+    """
+    path = resolve_artifact_path(
+        filename, base_dir=base_dir, subdir=subdir, must_exist=True
+    )
     if as_ == "bytes":
         return path.read_bytes()
     if as_ == "text":

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -91,6 +91,21 @@ def get_completion(
     api_provider: str,
     temperature: float = 0.7,
 ) -> str:
+    """Fetch a text completion.
+
+    Raises
+    ------
+    ProviderOperationError
+        If the provider call fails.
+
+    Example
+    -------
+    >>> client, model, provider = setup_llm_client()
+    >>> try:
+    ...     get_completion("Hello", client, model, provider)
+    ... except ProviderOperationError:
+    ...     ...
+    """
     prompt = normalize_prompt(prompt)
     provider_module = ensure_provider(client, api_provider, model_name, "completion")
     return provider_module.text_completion(client, prompt, model_name, temperature)
@@ -105,12 +120,18 @@ async def async_get_completion(
 ) -> str:
     """Asynchronously fetch a text completion.
 
+    Raises
+    ------
+    ProviderOperationError
+        If the provider call fails.
+
     Example
     -------
     >>> import asyncio
     >>> async def main(prompts):
+    ...     client, model, provider = await async_setup_llm_client()
     ...     tasks = [
-    ...         async_get_completion(p, client, model_name, api_provider)
+    ...         async_get_completion(p, client, model, provider)
     ...         for p in prompts
     ...     ]
     ...     return await asyncio.gather(*tasks)
@@ -133,6 +154,11 @@ def get_completion_compat(
     api_provider: str,
     temperature: float = 0.7,
 ) -> Tuple[Optional[str], Optional[str]]:
+    """Compatibility wrapper returning ``(result, error_str)``.
+
+    .. deprecated:: 1.0
+       Use :func:`get_completion` and catch :class:`ProviderOperationError`.
+    """
     try:
         return (
             get_completion(prompt, client, model_name, api_provider, temperature),
@@ -149,6 +175,11 @@ async def async_get_completion_compat(
     api_provider: str,
     temperature: float = 0.7,
 ) -> Tuple[Optional[str], Optional[str]]:
+    """Async compatibility wrapper returning ``(result, error_str)``.
+
+    .. deprecated:: 1.0
+       Use :func:`async_get_completion` and catch :class:`ProviderOperationError`.
+    """
     try:
         return (
             await async_get_completion(
@@ -163,6 +194,18 @@ async def async_get_completion_compat(
 def get_vision_completion(
     prompt: str, image_path_or_url: str, client: Any, model_name: str, api_provider: str
 ) -> str:
+    """Fetch a vision completion for ``image_path_or_url``.
+
+    Raises
+    ------
+    ProviderOperationError
+        If the provider call fails.
+
+    Example
+    -------
+    >>> client, model, provider = setup_llm_client()
+    >>> get_vision_completion("Describe", "image.png", client, model, provider)
+    """
     prompt = normalize_prompt(prompt)
     provider_module = ensure_provider(
         client, api_provider, model_name, "vision completion"
@@ -179,6 +222,20 @@ async def async_get_vision_completion(
     model_name: str,
     api_provider: str,
 ) -> str:
+    """Asynchronously fetch a vision completion for an image.
+
+    Raises
+    ------
+    ProviderOperationError
+        If the provider call fails.
+
+    Example
+    -------
+    >>> client, model, provider = await async_setup_llm_client()
+    >>> await async_get_vision_completion(
+    ...     "Describe", "image.png", client, model, provider
+    ... )
+    """
     prompt = normalize_prompt(prompt)
     provider_module = ensure_provider(
         client, api_provider, model_name, "vision completion"
@@ -203,6 +260,11 @@ def get_vision_completion_compat(
     model_name: str,
     api_provider: str,
 ) -> Tuple[Optional[str], Optional[str]]:
+    """Compatibility wrapper returning ``(result, error_str)``.
+
+    .. deprecated:: 1.0
+       Use :func:`get_vision_completion` and catch :class:`ProviderOperationError`.
+    """
     try:
         return (
             get_vision_completion(
@@ -221,6 +283,11 @@ async def async_get_vision_completion_compat(
     model_name: str,
     api_provider: str,
 ) -> Tuple[Optional[str], Optional[str]]:
+    """Async compatibility wrapper returning ``(result, error_str)``.
+
+    .. deprecated:: 1.0
+       Use :func:`async_get_vision_completion` and catch :class:`ProviderOperationError`.
+    """
     try:
         return (
             await async_get_vision_completion(
@@ -255,7 +322,18 @@ def prompt_enhancer(
     client: Any | None = None,
     api_provider: str | None = None,
 ) -> str:
-    """Enhance a raw user prompt using a meta-prompt optimization system."""
+    """Enhance a raw user prompt using a meta-prompt optimization system.
+
+    Raises
+    ------
+    ProviderOperationError
+        If prompt enhancement fails.
+
+    Example
+    -------
+    >>> client, model, provider = setup_llm_client("o3")
+    >>> prompt_enhancer("write a poem", model, client, provider)
+    """
     user_input = normalize_prompt(user_input)
     if not user_input:
         prov = api_provider or RECOMMENDED_MODELS.get(model_name, {}).get(
@@ -374,6 +452,11 @@ def prompt_enhancer_compat(
     client: Any | None = None,
     api_provider: str | None = None,
 ) -> Tuple[Optional[str], Optional[str]]:
+    """Compatibility wrapper returning ``(result, error_str)``.
+
+    .. deprecated:: 1.0
+       Use :func:`prompt_enhancer` and catch :class:`ProviderOperationError`.
+    """
     try:
         return prompt_enhancer(user_input, model_name, client, api_provider), None
     except ProviderOperationError as e:


### PR DESCRIPTION
## Summary
- document artifact path resolution and error behavior
- expand LLM helper docstrings with exception and async guidance
- add productionizing and artifacts guides and deprecation notes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c2f3c03c14833298a9ba62a92adfbc