### PR TITLE
Fix artifact path resolution to avoid nested folders

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,16 @@ def test_save_artifact_invalid_path(tmp_path):
     with pytest.raises(ArtifactSecurityError):
         artifacts.save_artifact({'x': 1}, '/tmp/test.json')
 
+
+def test_save_artifact_strips_redundant_folder(tmp_path):
+    artifacts_dir = tmp_path / 'artifacts'
+    artifacts.set_artifacts_dir(str(artifacts_dir))
+    saved_path = artifacts.save_artifact('hello', 'artifacts/sample.txt', overwrite=True)
+    assert saved_path == artifacts_dir / 'sample.txt'
+    assert not (artifacts_dir / 'artifacts').exists()
+    loaded = artifacts.load_artifact('artifacts/sample.txt', as_='text')
+    assert loaded == 'hello'
+
 def test_load_artifact_missing_file(tmp_path):
     artifacts.set_artifacts_dir(str(tmp_path))
     from utils.errors import ArtifactNotFoundError

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,18 @@ def test_save_artifact_strips_redundant_folder(tmp_path):
     loaded = artifacts.load_artifact('artifacts/sample.txt', as_='text')
     assert loaded == 'hello'
 
+def test_save_artifact_with_artifacts_in_name(tmp_path):
+    artifacts_dir = tmp_path / 'artifacts'
+    artifacts.set_artifacts_dir(str(artifacts_dir))
+    # should create .../artifacts/artifacts
+    saved_path = artifacts.save_artifact('hello', 'artifacts/artifacts', overwrite=True)
+    assert saved_path == artifacts_dir / 'artifacts'
+    assert saved_path.is_file()
+    assert saved_path.read_text() == 'hello'
+    # and loading should work
+    loaded = artifacts.load_artifact('artifacts/artifacts', as_='text')
+    assert loaded == 'hello'
+
 def test_load_artifact_missing_file(tmp_path):
     artifacts.set_artifacts_dir(str(tmp_path))
     from utils.errors import ArtifactNotFoundError

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -103,8 +103,27 @@ def resolve_artifact_path(
             )
         final = resolved
     else:
+        cleaned_target = target
+        if subdir is None:
+            base_name = base.name
+            if base_name:
+                base_segment = Path(base_name)
+                while True:
+                    try:
+                        relative_target = cleaned_target.relative_to(base_segment)
+                    except ValueError:
+                        break
+                    if relative_target == Path('.'):
+                        raise ArtifactError(
+                            "Filename must not resolve to the artifacts directory itself."
+                        )
+                    cleaned_target = relative_target
         # allow optional subdir
-        final = (base / (Path(subdir) if subdir else Path()) / target).resolve()
+        final = (
+            base
+            / (Path(subdir) if subdir else Path())
+            / cleaned_target
+        ).resolve()
         if not _is_within(final, base):
             raise ArtifactSecurityError(
                 f"Resolved path '{final}' escapes artifacts dir '{base}'."

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -106,7 +106,8 @@ def resolve_artifact_path(
         cleaned_target = target
         if subdir is None:
             base_name = base.name
-            if base_name:
+            # Validate base_name: must be non-empty and not contain path separators
+            if base_name and os.sep not in base_name and (os.altsep is None or os.altsep not in base_name):
                 base_segment = Path(base_name)
                 while True:
                     try:


### PR DESCRIPTION
## Summary
- strip redundant leading `artifacts/` segments when resolving artifact filenames
- prevent treating the artifacts directory itself as a file target
- add regression test ensuring prefixed artifact paths do not create nested folders

## Testing
- PYTHONPATH=. pytest tests/test_utils.py::test_save_artifact_strips_redundant_folder -q

------
https://chatgpt.com/codex/tasks/task_e_68d07bb6c89c8332b5fbfb734ce9a0fc