### PR TITLE
Standardize American English spellings in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ The `Supporting Materials/` directory contains detailed guides that extend this 
 
 * **Environment Setup Guide** – Step-by-step environment bootstrap with troubleshooting tips for common installation issues.
 * **Artifacts Guide** – Deep dive on `utils.artifacts`, directory overrides, and security guarantees.
-* **Docker Guide** – Conceptual and hands-on introduction to containerising the FastAPI projects you assemble in the labs.
+* **Docker Guide** – Conceptual and hands-on introduction to containerizing the FastAPI projects you assemble in the labs.
 * **Deployment Guide (Onboarding Tool)** – Blueprint for stitching the Day 1–Day 7 artifacts into a full-stack onboarding assistant, including container choices and wiring diagrams.
 * **React Components Viewing Guide** – Zero-build workflow for rendering JSX snippets generated during the front-end labs.
 * **Productionizing Utils** – Environment variables, rate limiting, logging, and retry configuration for taking the helper library beyond notebooks.
 
-Each document has been refreshed to match the utilities and lab artefacts in this repository. Start there whenever you need deeper context or run into an edge case during class.
+Each document has been refreshed to match the utilities and lab artifacts in this repository. Start there whenever you need deeper context or run into an edge case during class.
 
 ---
 
@@ -194,7 +194,7 @@ For classroom delivery, instructors typically:
 
 ## 📄 License & Support
 
-* **License:** These materials are licensed for classroom use by Digital Ethos Academy cohorts. If you need clarification on redistribution rights, contact your program coordinator before sharing content outside your organisation.
+* **License:** These materials are licensed for classroom use by Digital Ethos Academy cohorts. If you need clarification on redistribution rights, contact your program coordinator before sharing content outside your organization.
 * **Support:**
   * Environment or dependency issues – follow the troubleshooting section in the Environment Setup Guide.
   * Lab blockers – compare your progress with the matching notebook in `Solutions/`.

--- a/Supporting Materials/Deployment_Guide_Onboarding_Tool.md
+++ b/Supporting Materials/Deployment_Guide_Onboarding_Tool.md
@@ -74,7 +74,7 @@ Remember to keep business logic (FastAPI, agents) in the backend and UI logic in
 
 ---
 
-## 4. Containerisation Strategy
+## 4. Containerization Strategy
 
 Once the backend and frontend are wired together locally, package everything into a Docker image. Below is a multi-stage Dockerfile that mirrors what you generate in the Day 5 CI/CD lab. Adjust paths if your folder structure differs.
 
@@ -153,7 +153,7 @@ For each option, ensure environment variables (API keys, vector store URLs, opti
 1. Finish the core labs and export code/artifacts into source files.
 2. Test the FastAPI backend locally (`uvicorn app.main:app --reload`).
 3. Wire up the React frontend and confirm all flows against the live backend.
-4. Containerise using the multi-stage Dockerfile and run the image locally.
+4. Containerize using the multi-stage Dockerfile and run the image locally.
 5. Deploy to your chosen environment and monitor logs for the first set of user journeys.
 
 When each layer passes acceptance tests, you have successfully transformed the daily lab outputs into a cohesive onboarding assistant ready for stakeholders to trial.

--- a/Supporting Materials/Docker_Guide.md
+++ b/Supporting Materials/Docker_Guide.md
@@ -1,6 +1,6 @@
 # Docker Guide for the AI-Driven Software Engineering Program
 
-Docker is the bridge between the code you generate in the labs and a reliable deployment environment. This guide introduces Docker concepts, explains how they relate to our FastAPI + React onboarding tool, and shows you how to containerise the project using artifacts produced throughout the course.
+Docker is the bridge between the code you generate in the labs and a reliable deployment environment. This guide introduces Docker concepts, explains how they relate to our FastAPI + React onboarding tool, and shows you how to containerize the project using artifacts produced throughout the course.
 
 ---
 

--- a/Supporting Materials/Environment_Setup_Guide.md
+++ b/Supporting Materials/Environment_Setup_Guide.md
@@ -15,7 +15,7 @@ This guide walks you through preparing a reliable workspace for the Digital Etho
 | **Hardware** | Minimum 8 GB RAM, 10 GB free disk space, stable internet connection. |
 | **Accounts** | GitHub, OpenAI API key (core labs), plus optional Anthropic, Google Gemini, or Hugging Face keys for advanced exercises. |
 
-> If you are learning in a classroom, ask your facilitator to confirm which providers your organisation allows.
+> If you are learning in a classroom, ask your facilitator to confirm which providers your organization allows.
 
 ---
 
@@ -88,7 +88,7 @@ HUGGINGFACE_API_KEY="hf_..."     # Optional, for open-source model exploration
 **Best practices:**
 
 * Never commit `.env` to version control.
-* Use separate keys for development vs. production if your organisation requires audit logging.
+* Use separate keys for development vs. production if your organization requires audit logging.
 * If you cannot obtain a provider key, you can still run planning and design labs; code execution labs will require keys to access LLM functionality.
 
 ---

--- a/Supporting Materials/How_to_View_Your_React_Components_Locally.md
+++ b/Supporting Materials/How_to_View_Your_React_Components_Locally.md
@@ -109,7 +109,7 @@ This mirrors the wiring you will perform later in the deployment guide.
 
 ---
 
-## Organising Components
+## Organizing Components
 
 * Store raw lab outputs under version control (e.g., `Labs/Day_08_Vision_and_Evaluation/generated_components/`).
 * Save polished versions to `frontend/src/components/` once you are ready to integrate them with the backend.


### PR DESCRIPTION
## Summary
- update README links and descriptions to use American English spellings for artifacts and containerizing
- align deployment and Docker guides with American English terminology
- standardize supporting guides on organization/organizing language for consistency

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d0e2b56f70833289ad00cd838c4ec3